### PR TITLE
Add zig-ecs integration for direct ECS support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,6 +8,10 @@ pub fn build(b: *std.Build) void {
     const zig_utils_dep = b.dependency("zig_utils", .{});
     const zig_utils = zig_utils_dep.module("zig_utils");
 
+    // zig-ecs dependency
+    const zig_ecs_dep = b.dependency("zig_ecs", .{});
+    const zig_ecs = zig_ecs_dep.module("zig-ecs");
+
     // Main module
     const pathfinding_module = b.addModule("pathfinding", .{
         .root_source_file = b.path("src/pathfinding.zig"),
@@ -15,6 +19,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .imports = &.{
             .{ .name = "zig_utils", .module = zig_utils },
+            .{ .name = "zig_ecs", .module = zig_ecs },
         },
     });
 
@@ -32,6 +37,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .imports = &.{
                 .{ .name = "zig_utils", .module = zig_utils },
+                .{ .name = "zig_ecs", .module = zig_ecs },
             },
         }),
     });
@@ -50,6 +56,7 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "zspec", .module = zspec.module("zspec") },
                 .{ .name = "pathfinding", .module = pathfinding_module },
                 .{ .name = "zig_utils", .module = zig_utils },
+                .{ .name = "zig_ecs", .module = zig_ecs },
             },
         }),
         .test_runner = .{ .path = zspec.path("src/runner.zig"), .mode = .simple },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,6 +12,10 @@
             .url = "https://github.com/apotema/zspec/archive/refs/heads/main.tar.gz",
             .hash = "zspec-0.3.0-jaKLbbqZAgAB-MBfy6M3HKB3jSTQ-TsNW9OxpLhLlav5",
         },
+        .zig_ecs = .{
+            .url = "git+https://github.com/prime31/zig-ecs#dbf3647c2cc4f327fe87067e40f8436c7f87f209",
+            .hash = "entt-1.0.0-qJPtbNLVAgDPXaUbyRSsBTK75Cr1WujUA92kToJugWry",
+        },
     },
     .paths = .{
         "build.zig",

--- a/src/components.zig
+++ b/src/components.zig
@@ -1,23 +1,27 @@
 //! Pathfinding Components
 //!
 //! ECS components for node-based pathfinding systems.
-//! These components can be used with any ECS library.
+//! Designed for use with zig-ecs Registry.
 
 const std = @import("std");
+const ecs = @import("zig_ecs");
+
+/// Entity type from zig-ecs
+pub const Entity = ecs.Entity;
 
 /// A node in a movement graph with directional links to neighbors.
 /// Supports 4-directional movement (left, right, up, down).
 pub const MovementNode = struct {
-    left_entt: ?u32 = null,
-    right_entt: ?u32 = null,
-    up_entt: ?u32 = null,
-    down_entt: ?u32 = null,
+    left_entt: ?Entity = null,
+    right_entt: ?Entity = null,
+    up_entt: ?Entity = null,
+    down_entt: ?Entity = null,
 };
 
 /// Tracks the closest movement node to an entity.
 /// Updated by spatial queries (quad tree, grid, etc.)
 pub const ClosestMovementNode = struct {
-    node_entt: u32 = 0,
+    node_entt: ?Entity = null,
     distance: f32 = 0,
 };
 
@@ -25,7 +29,7 @@ pub const ClosestMovementNode = struct {
 pub const MovingTowards = struct {
     target_x: f32 = 0,
     target_y: f32 = 0,
-    closest_node_entt: u32 = 0,
+    closest_node_entt: ?Entity = null,
     speed: f32 = 10,
 };
 
@@ -33,7 +37,7 @@ pub const MovingTowards = struct {
 /// Manages its own memory for the path array.
 pub const WithPath = struct {
     allocator: std.mem.Allocator,
-    path: std.ArrayListUnmanaged(u32) = .empty,
+    path: std.ArrayListUnmanaged(Entity) = .empty,
 
     pub fn init(allocator: std.mem.Allocator) WithPath {
         return .{ .allocator = allocator, .path = .empty };
@@ -43,7 +47,7 @@ pub const WithPath = struct {
         self.path.deinit(self.allocator);
     }
 
-    pub fn append(self: *WithPath, node: u32) !void {
+    pub fn append(self: *WithPath, node: Entity) !void {
         try self.path.append(self.allocator, node);
     }
 
@@ -55,12 +59,12 @@ pub const WithPath = struct {
         return self.path.items.len == 0;
     }
 
-    pub fn popFront(self: *WithPath) ?u32 {
+    pub fn popFront(self: *WithPath) ?Entity {
         if (self.path.items.len == 0) return null;
         return self.path.orderedRemove(0);
     }
 
-    pub fn peekFront(self: *const WithPath) ?u32 {
+    pub fn peekFront(self: *const WithPath) ?Entity {
         if (self.path.items.len == 0) return null;
         return self.path.items[0];
     }

--- a/tests/components_spec.zig
+++ b/tests/components_spec.zig
@@ -1,18 +1,30 @@
 const std = @import("std");
 const zspec = @import("zspec");
 const pathfinding = @import("pathfinding");
+const zig_ecs = @import("zig_ecs");
 
 const expect = zspec.expect;
+const Entity = pathfinding.Entity;
+const Registry = pathfinding.Registry;
 
 pub const WithPathSpec = struct {
     var with_path: pathfinding.WithPath = undefined;
+    var registry: Registry = undefined;
+    var test_entities: [3]Entity = undefined;
 
     test "tests:before" {
+        registry = Registry.init(std.testing.allocator);
         with_path = pathfinding.WithPath.init(std.testing.allocator);
+
+        // Create test entities for use in tests
+        test_entities[0] = registry.create();
+        test_entities[1] = registry.create();
+        test_entities[2] = registry.create();
     }
 
     test "tests:after" {
         with_path.deinit();
+        registry.deinit();
     }
 
     pub const @"initialization" = struct {
@@ -31,9 +43,9 @@ pub const WithPathSpec = struct {
 
     pub const @"with nodes added" = struct {
         test "tests:before" {
-            try with_path.append(10);
-            try with_path.append(20);
-            try with_path.append(30);
+            try with_path.append(test_entities[0]);
+            try with_path.append(test_entities[1]);
+            try with_path.append(test_entities[2]);
         }
 
         test "tests:after" {
@@ -45,16 +57,16 @@ pub const WithPathSpec = struct {
         }
 
         test "peekFront returns first node without removing" {
-            try expect.equal(with_path.peekFront().?, 10);
-            try expect.equal(with_path.peekFront().?, 10);
+            try expect.equal(with_path.peekFront().?, test_entities[0]);
+            try expect.equal(with_path.peekFront().?, test_entities[0]);
         }
     };
 
     pub const @"popFront behavior" = struct {
         test "tests:before" {
-            try with_path.append(1);
-            try with_path.append(2);
-            try with_path.append(3);
+            try with_path.append(test_entities[0]);
+            try with_path.append(test_entities[1]);
+            try with_path.append(test_entities[2]);
         }
 
         test "tests:after" {
@@ -62,16 +74,16 @@ pub const WithPathSpec = struct {
         }
 
         test "returns nodes in FIFO order" {
-            try expect.equal(with_path.popFront().?, 1);
-            try expect.equal(with_path.popFront().?, 2);
-            try expect.equal(with_path.popFront().?, 3);
+            try expect.equal(with_path.popFront().?, test_entities[0]);
+            try expect.equal(with_path.popFront().?, test_entities[1]);
+            try expect.equal(with_path.popFront().?, test_entities[2]);
             try expect.toBeNull(with_path.popFront());
         }
     };
 
     pub const @"clear behavior" = struct {
         test "tests:before" {
-            try with_path.append(100);
+            try with_path.append(test_entities[0]);
         }
 
         test "tests:after" {
@@ -97,49 +109,88 @@ pub const MovementNodeSpec = struct {
     };
 
     pub const @"with connections" = struct {
+        var registry: Registry = undefined;
+        var entities: [4]Entity = undefined;
+
+        test "tests:before" {
+            registry = Registry.init(std.testing.allocator);
+            entities[0] = registry.create();
+            entities[1] = registry.create();
+            entities[2] = registry.create();
+            entities[3] = registry.create();
+        }
+
+        test "tests:after" {
+            registry.deinit();
+        }
+
         test "stores directional connections" {
             const node = pathfinding.MovementNode{
-                .left_entt = 1,
-                .right_entt = 2,
-                .up_entt = 3,
-                .down_entt = 4,
+                .left_entt = entities[0],
+                .right_entt = entities[1],
+                .up_entt = entities[2],
+                .down_entt = entities[3],
             };
-            try expect.equal(node.left_entt.?, 1);
-            try expect.equal(node.right_entt.?, 2);
-            try expect.equal(node.up_entt.?, 3);
-            try expect.equal(node.down_entt.?, 4);
+            try expect.equal(node.left_entt.?, entities[0]);
+            try expect.equal(node.right_entt.?, entities[1]);
+            try expect.equal(node.up_entt.?, entities[2]);
+            try expect.equal(node.down_entt.?, entities[3]);
         }
     };
 };
 
 pub const ClosestMovementNodeSpec = struct {
+    var registry: Registry = undefined;
+    var test_entity: Entity = undefined;
+
+    test "tests:before" {
+        registry = Registry.init(std.testing.allocator);
+        test_entity = registry.create();
+    }
+
+    test "tests:after" {
+        registry.deinit();
+    }
+
     test "stores node entity and distance" {
         const closest = pathfinding.ClosestMovementNode{
-            .node_entt = 42,
+            .node_entt = test_entity,
             .distance = 15.5,
         };
-        try expect.equal(closest.node_entt, 42);
+        try expect.equal(closest.node_entt.?, test_entity);
         try expect.equal(closest.distance, 15.5);
     }
 
     test "has default values" {
         const closest = pathfinding.ClosestMovementNode{};
-        try expect.equal(closest.node_entt, 0);
+        try expect.toBeNull(closest.node_entt);
         try expect.equal(closest.distance, 0);
     }
 };
 
 pub const MovingTowardsSpec = struct {
+    var registry: Registry = undefined;
+    var test_entity: Entity = undefined;
+
+    test "tests:before" {
+        registry = Registry.init(std.testing.allocator);
+        test_entity = registry.create();
+    }
+
+    test "tests:after" {
+        registry.deinit();
+    }
+
     test "stores movement target and speed" {
         const moving = pathfinding.MovingTowards{
             .target_x = 100.5,
             .target_y = 200.5,
-            .closest_node_entt = 5,
+            .closest_node_entt = test_entity,
             .speed = 25.0,
         };
         try expect.equal(moving.target_x, 100.5);
         try expect.equal(moving.target_y, 200.5);
-        try expect.equal(moving.closest_node_entt, 5);
+        try expect.equal(moving.closest_node_entt.?, test_entity);
         try expect.equal(moving.speed, 25.0);
     }
 
@@ -147,7 +198,7 @@ pub const MovingTowardsSpec = struct {
         const moving = pathfinding.MovingTowards{};
         try expect.equal(moving.target_x, 0);
         try expect.equal(moving.target_y, 0);
-        try expect.equal(moving.closest_node_entt, 0);
+        try expect.toBeNull(moving.closest_node_entt);
         try expect.equal(moving.speed, 10);
     }
 };


### PR DESCRIPTION
## Summary
- Add zig-ecs dependency (prime31/zig-ecs) for direct ECS integration
- Rewrite MovementNodeController to query Registry directly instead of using generic quad tree interface
- Update all components to use `ecs.Entity` type for entity references
- Re-export `Entity` and `Registry` types from pathfinding module for convenience

## Changes
- **build.zig.zon**: Added zig-ecs dependency
- **build.zig**: Added zig_ecs module imports to pathfinding module and tests
- **src/movement_node_controller.zig**: Complete rewrite to use Registry views for finding closest movement nodes
- **src/components.zig**: Changed u32 entity references to optional `?Entity` type
- **src/pathfinding.zig**: Updated documentation and re-exports Entity/Registry
- **tests/**: Updated all tests for new ECS-based API

## Breaking Changes
- `ClosestMovementNode.node_entt` is now `?Entity` (optional) instead of `u32`
- `MovingTowards.closest_node_entt` is now `?Entity` (optional) instead of `u32`
- `MovementNodeController.getClosestMovementNode` now takes `*Registry` parameter
- `WithPath` now stores `Entity` instead of `u32`

## Test plan
- [x] Run `zig build test` - all unit tests pass
- [x] Run `zig build spec` - all 91 zspec tests pass
- [x] Run `zig build run-examples` - all examples work correctly

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)