### PR TITLE
Fix module name collision: rename zig_ecs to ecs

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .imports = &.{
             .{ .name = "zig_utils", .module = zig_utils },
-            .{ .name = "zig_ecs", .module = zig_ecs },
+            .{ .name = "ecs", .module = zig_ecs },
         },
     });
 
@@ -37,7 +37,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .imports = &.{
                 .{ .name = "zig_utils", .module = zig_utils },
-                .{ .name = "zig_ecs", .module = zig_ecs },
+                .{ .name = "ecs", .module = zig_ecs },
             },
         }),
     });
@@ -56,7 +56,7 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "zspec", .module = zspec.module("zspec") },
                 .{ .name = "pathfinding", .module = pathfinding_module },
                 .{ .name = "zig_utils", .module = zig_utils },
-                .{ .name = "zig_ecs", .module = zig_ecs },
+                .{ .name = "ecs", .module = zig_ecs },
             },
         }),
         .test_runner = .{ .path = zspec.path("src/runner.zig"), .mode = .simple },

--- a/src/components.zig
+++ b/src/components.zig
@@ -4,7 +4,7 @@
 //! Designed for use with zig-ecs Registry.
 
 const std = @import("std");
-const ecs = @import("zig_ecs");
+const ecs = @import("ecs");
 
 /// Entity type from zig-ecs
 pub const Entity = ecs.Entity;

--- a/src/movement_node_controller.zig
+++ b/src/movement_node_controller.zig
@@ -5,7 +5,7 @@
 
 const std = @import("std");
 const zig_utils = @import("zig_utils");
-const ecs = @import("zig_ecs");
+const ecs = @import("ecs");
 
 const components = @import("components.zig");
 

--- a/src/pathfinding.zig
+++ b/src/pathfinding.zig
@@ -19,7 +19,7 @@
 //! ## Example (ECS Integration)
 //! ```zig
 //! const pathfinding = @import("pathfinding");
-//! const ecs = @import("zig_ecs");
+//! const ecs = @import("ecs");
 //!
 //! var registry = ecs.Registry.init(allocator);
 //! defer registry.deinit();
@@ -86,7 +86,7 @@
 
 const std = @import("std");
 pub const zig_utils = @import("zig_utils");
-pub const ecs = @import("zig_ecs");
+pub const ecs = @import("ecs");
 
 // Re-export Position (Vector2) from zig-utils for convenience
 pub const Position = zig_utils.Vector2;

--- a/tests/components_spec.zig
+++ b/tests/components_spec.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const zspec = @import("zspec");
 const pathfinding = @import("pathfinding");
-const zig_ecs = @import("zig_ecs");
+const ecs = @import("ecs");
 
 const expect = zspec.expect;
 const Entity = pathfinding.Entity;

--- a/tests/controller_spec.zig
+++ b/tests/controller_spec.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const zspec = @import("zspec");
 const pathfinding = @import("pathfinding");
-const zig_ecs = @import("zig_ecs");
+const ecs = @import("ecs");
 
 const expect = zspec.expect;
 const Position = pathfinding.Position;


### PR DESCRIPTION
## Summary

- Renamed internal zig-ecs module from `zig_ecs` to `ecs` to prevent compilation errors when projects use both labelle-pathfinding and zig-ecs with the standard `ecs` module name
- Updated all source files and tests to use the new module name
- Ensures compatibility with labelle library conventions and common Zig ecosystem patterns

Fixes #7

## Test plan

- [x] All 91 unit and spec tests pass
- [x] All usage examples run correctly
- [x] Verified imports work with the new module name

🤖 Generated with [Claude Code](https://claude.com/claude-code)