### PR TITLE
feat: migrate to Zig 0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Checkout labelle-core
-        run: git clone --depth 1 https://github.com/labelle-toolkit/labelle-core.git ../labelle-core
+        run: git clone --depth 1 --branch feat/zig-0.16-migration https://github.com/labelle-toolkit/labelle-core.git ../labelle-core
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Run unit tests
         run: zig build test

--- a/build.zig
+++ b/build.zig
@@ -227,7 +227,7 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
-    raylib_example.linkLibrary(raylib_artifact);
+    raylib_example.root_module.linkLibrary(raylib_artifact);
     b.installArtifact(raylib_example);
 
     const run_raylib = b.addRunArtifact(raylib_example);
@@ -247,7 +247,7 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
-    raylib_building.linkLibrary(raylib_artifact);
+    raylib_building.root_module.linkLibrary(raylib_artifact);
     b.installArtifact(raylib_building);
 
     const run_raylib_building = b.addRunArtifact(raylib_building);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,22 +2,22 @@
     .name = .labelle_pathfinding,
     .version = "2.7.0",
     .fingerprint = 0x15f62ccc39d14685,
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zig_utils = .{
-            .url = "git+https://github.com/labelle-toolkit/zig-utils#0eb76432845d30a8744d0f1e7b2f184bde30ef25",
-            .hash = "zig_utils-0.1.0-dUo89-MYAABNGtQuVNvsszZwByyjALW-LLaqVZYTkI_I",
+            .url = "git+https://github.com/labelle-toolkit/zig-utils.git?ref=feat/zig-0.16-migration#fa5758304d113679d9bd82187b2bad5fde95554e",
+            .hash = "zig_utils-0.6.1-dUo895zOAQAfpupehxPVlrar8v-EktyljpxzVal5jeJ4",
         },
         .labelle_core = .{
             .path = "../labelle-core",
         },
         .zspec = .{
-            .url = "https://github.com/apotema/zspec/archive/refs/heads/main.tar.gz",
-            .hash = "zspec-0.7.0-jaKLbVqmAwDxLB7GYHuw354BQp7_uBSN9rSBUIfAx5xy",
+            .url = "git+https://github.com/apotema/zspec.git?ref=feat/zig-0.16-migration#42e1e69e31a6971c93e6807d29eabe30d9f46bd6",
+            .hash = "zspec-0.8.0-jaKLbe3SAwDRIFxFJbSQvz_lr9Xn-trRT9KR16I8C5_P",
         },
         .raylib_zig = .{
-            .url = "git+https://github.com/raylib-zig/raylib-zig#a4d18b2d1cf8fdddec68b5b084535fca0475f466",
-            .hash = "raylib_zig-5.6.0-dev-KE8REL5MBQAf3p497t52Xw9P7ojndIkVOWPXnLiLLw2P",
+            .url = "git+https://github.com/raylib-zig/raylib-zig?ref=devel#f25c5173b4c40ef53c7ccf6d8d51ead0892f9f22",
+            .hash = "raylib_zig-6.0.0-KE8REDJ4BQBu7lKwYNt6R4j5ywPeS37zqW6zrtjCcRwH",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,8 +12,8 @@
             .path = "../labelle-core",
         },
         .zspec = .{
-            .url = "https://github.com/apotema/zspec/archive/v0.9.0.tar.gz",
-            .hash = "zspec-0.9.0-jaKLba73AwB5EK3YFyhpQ4roFBA_hhGbVvjSjur3KxZz",
+            .url = "https://github.com/apotema/zspec/archive/v0.9.1.tar.gz",
+            .hash = "zspec-0.9.1-jaKLbbX4AwBKANdetxzzWc3UTO0UY0lcJJzTagQHlt5K",
         },
         .raylib_zig = .{
             .url = "git+https://github.com/raylib-zig/raylib-zig?ref=devel#f25c5173b4c40ef53c7ccf6d8d51ead0892f9f22",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,8 +12,8 @@
             .path = "../labelle-core",
         },
         .zspec = .{
-            .url = "git+https://github.com/apotema/zspec.git?ref=feat/zig-0.16-migration#42e1e69e31a6971c93e6807d29eabe30d9f46bd6",
-            .hash = "zspec-0.8.0-jaKLbe3SAwDRIFxFJbSQvz_lr9Xn-trRT9KR16I8C5_P",
+            .url = "https://github.com/apotema/zspec/archive/v0.9.0.tar.gz",
+            .hash = "zspec-0.9.0-jaKLba73AwB5EK3YFyhpQ4roFBA_hhGbVvjSjur3KxZz",
         },
         .raylib_zig = .{
             .url = "git+https://github.com/raylib-zig/raylib-zig?ref=devel#f25c5173b4c40ef53c7ccf6d8d51ead0892f9f22",

--- a/src/a_star.zig
+++ b/src/a_star.zig
@@ -201,15 +201,15 @@ pub const AStar = struct {
         var closed_set = std.AutoHashMap(u32, void).init(self.allocator);
         defer closed_set.deinit();
 
-        var open_set = std.PriorityQueue(PQNode, void, PQNode.compare).init(self.allocator, {});
-        defer open_set.deinit();
+        var open_set = std.PriorityQueue(PQNode, void, PQNode.compare).initContext({});
+        defer open_set.deinit(self.allocator);
 
         // Initialize source
         try g_score.put(source, 0);
         const h = self.calculateHeuristic(source, dest);
-        try open_set.add(.{ .vertex = source, .f_score = h });
+        try open_set.push(self.allocator, .{ .vertex = source, .f_score = h });
 
-        while (open_set.removeOrNull()) |current| {
+        while (open_set.pop()) |current| {
             if (current.vertex == dest) {
                 // Reconstruct path
                 var node = dest;
@@ -247,7 +247,7 @@ pub const AStar = struct {
                     try g_score.put(edge.to, tentative_g);
 
                     const f = @as(f32, @floatFromInt(tentative_g)) + self.calculateHeuristic(edge.to, dest);
-                    try open_set.add(.{ .vertex = edge.to, .f_score = f });
+                    try open_set.push(self.allocator, .{ .vertex = edge.to, .f_score = f });
                 }
             }
         }
@@ -488,15 +488,15 @@ pub fn AStarWithHooks(comptime Dispatcher: type) type {
             var closed_set = std.AutoHashMap(u32, void).init(self.base.allocator);
             defer closed_set.deinit();
 
-            var open_set = std.PriorityQueue(AStar.PQNode, void, AStar.PQNode.compare).init(self.base.allocator, {});
-            defer open_set.deinit();
+            var open_set = std.PriorityQueue(AStar.PQNode, void, AStar.PQNode.compare).initContext({});
+            defer open_set.deinit(self.base.allocator);
 
             // Initialize source
             try g_score.put(source, 0);
             const h = self.base.calculateHeuristic(source, dest);
-            try open_set.add(.{ .vertex = source, .f_score = h });
+            try open_set.push(self.base.allocator, .{ .vertex = source, .f_score = h });
 
-            while (open_set.removeOrNull()) |current| {
+            while (open_set.pop()) |current| {
                 nodes_explored += 1;
 
                 const current_g = g_score.get(current.vertex) orelse INF;
@@ -537,7 +537,7 @@ pub fn AStarWithHooks(comptime Dispatcher: type) type {
                         try g_score.put(edge.to, tentative_g);
 
                         const f = @as(f32, @floatFromInt(tentative_g)) + self.base.calculateHeuristic(edge.to, dest);
-                        try open_set.add(.{ .vertex = edge.to, .f_score = f });
+                        try open_set.push(self.base.allocator, .{ .vertex = edge.to, .f_score = f });
                     }
                 }
             }
@@ -618,15 +618,15 @@ pub fn AStarWithHooks(comptime Dispatcher: type) type {
             var closed_set = std.AutoHashMap(u32, void).init(self.base.allocator);
             defer closed_set.deinit();
 
-            var open_set = std.PriorityQueue(AStar.PQNode, void, AStar.PQNode.compare).init(self.base.allocator, {});
-            defer open_set.deinit();
+            var open_set = std.PriorityQueue(AStar.PQNode, void, AStar.PQNode.compare).initContext({});
+            defer open_set.deinit(self.base.allocator);
 
             // Initialize source
             try g_score.put(source, 0);
             const h = self.base.calculateHeuristic(source, dest);
-            try open_set.add(.{ .vertex = source, .f_score = h });
+            try open_set.push(self.base.allocator, .{ .vertex = source, .f_score = h });
 
-            while (open_set.removeOrNull()) |current| {
+            while (open_set.pop()) |current| {
                 nodes_explored += 1;
 
                 const current_g = g_score.get(current.vertex) orelse INF;
@@ -689,7 +689,7 @@ pub fn AStarWithHooks(comptime Dispatcher: type) type {
                         try g_score.put(edge.to, tentative_g);
 
                         const f = @as(f32, @floatFromInt(tentative_g)) + self.base.calculateHeuristic(edge.to, dest);
-                        try open_set.add(.{ .vertex = edge.to, .f_score = f });
+                        try open_set.push(self.base.allocator, .{ .vertex = edge.to, .f_score = f });
                     }
                 }
             }

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -176,7 +176,7 @@ pub fn PathfindingEngine(comptime Config: type) type {
             mode: StairMode,
             current_direction: ?VerticalDirection = null,
             users_count: u32 = 0,
-            waiting_queue: std.ArrayListUnmanaged(Entity) = .{},
+            waiting_queue: std.ArrayListUnmanaged(Entity) = .empty,
 
             pub fn canEnter(self: *const StairState, dir: VerticalDirection) bool {
                 return switch (self.mode) {
@@ -211,7 +211,7 @@ pub fn PathfindingEngine(comptime Config: type) type {
         /// Waiting area for entities queued at a stair
         pub const WaitingArea = struct {
             stair_node: NodeId,
-            waiting_spots: std.ArrayListUnmanaged(NodeId) = .{},
+            waiting_spots: std.ArrayListUnmanaged(NodeId) = .empty,
             /// Tracks which spots are occupied (spot NodeId -> occupying Entity)
             occupied_spots: std.AutoHashMap(NodeId, Entity) = undefined,
 
@@ -296,11 +296,11 @@ pub fn PathfindingEngine(comptime Config: type) type {
                 .entity_spatial = try QuadTree(Entity).init(allocator, .{ .x = -50000, .y = -50000, .width = 100000, .height = 100000 }),
                 .stair_states = std.AutoHashMap(NodeId, StairState).init(allocator),
                 .waiting_areas = std.AutoHashMap(NodeId, WaitingArea).init(allocator),
-                .node_reached_events = .{},
-                .path_completed_events = .{},
-                .path_blocked_events = .{},
-                .waiting_started_events = .{},
-                .waiting_ended_events = .{},
+                .node_reached_events = .empty,
+                .path_completed_events = .empty,
+                .path_blocked_events = .empty,
+                .waiting_started_events = .empty,
+                .waiting_ended_events = .empty,
             };
         }
 
@@ -469,7 +469,7 @@ pub fn PathfindingEngine(comptime Config: type) type {
             self.directional_edges.clearRetainingCapacity();
 
             // Rebuild node spatial index
-            var points: std.ArrayListUnmanaged(Point2D) = .{};
+            var points: std.ArrayListUnmanaged(Point2D) = .empty;
             defer points.deinit(self.allocator);
 
             var node_iter = self.nodes.iterator();
@@ -574,7 +574,7 @@ pub fn PathfindingEngine(comptime Config: type) type {
         }
 
         fn connectOmnidirectional(self: *Self, max_distance: f32, max_connections: u8) !void {
-            var buffer: std.ArrayListUnmanaged(EntityPoint(NodeId)) = .{};
+            var buffer: std.ArrayListUnmanaged(EntityPoint(NodeId)) = .empty;
             defer buffer.deinit(self.allocator);
 
             var node_iter = self.nodes.iterator();
@@ -612,7 +612,7 @@ pub fn PathfindingEngine(comptime Config: type) type {
         }
 
         fn connectDirectional(self: *Self, horizontal_range: f32, vertical_range: f32) !void {
-            var buffer: std.ArrayListUnmanaged(EntityPoint(NodeId)) = .{};
+            var buffer: std.ArrayListUnmanaged(EntityPoint(NodeId)) = .empty;
             defer buffer.deinit(self.allocator);
 
             var node_iter = self.nodes.iterator();
@@ -675,7 +675,7 @@ pub fn PathfindingEngine(comptime Config: type) type {
         /// Building mode: horizontal connections + stair-based vertical connections
         /// Vertical connections only occur between stair nodes
         fn connectBuilding(self: *Self, horizontal_range: f32, floor_height: f32) !void {
-            var buffer: std.ArrayListUnmanaged(EntityPoint(NodeId)) = .{};
+            var buffer: std.ArrayListUnmanaged(EntityPoint(NodeId)) = .empty;
             defer buffer.deinit(self.allocator);
 
             var node_iter = self.nodes.iterator();
@@ -787,7 +787,7 @@ pub fn PathfindingEngine(comptime Config: type) type {
         fn addEdgeInternal(self: *Self, from: NodeId, to: NodeId) !void {
             const entry = try self.edges.getOrPut(from);
             if (!entry.found_existing) {
-                entry.value_ptr.* = .{};
+                entry.value_ptr.* = .empty;
             }
             // Check if edge already exists
             for (entry.value_ptr.items) |existing| {
@@ -873,7 +873,7 @@ pub fn PathfindingEngine(comptime Config: type) type {
                 .edge_progress = 0,
                 .target_node = null,
                 .speed = speed,
-                .path = .{},
+                .path = .empty,
                 .path_index = 0,
             };
 
@@ -970,7 +970,7 @@ pub fn PathfindingEngine(comptime Config: type) type {
                 return error.NoPathExists;
             }
 
-            var path_list: std.ArrayListUnmanaged(u32) = .{};
+            var path_list: std.ArrayListUnmanaged(u32) = .empty;
             defer path_list.deinit(self.allocator);
             try self.floyd_warshall.setPathWithMappingUnmanaged(self.allocator, &path_list, pos.current_node, target);
 
@@ -1038,7 +1038,7 @@ pub fn PathfindingEngine(comptime Config: type) type {
 
         /// Get all entities within a radius
         pub fn getEntitiesInRadius(self: *Self, x: f32, y: f32, radius: f32, buffer: []Entity) []Entity {
-            var result_buffer: std.ArrayListUnmanaged(EntityPoint(Entity)) = .{};
+            var result_buffer: std.ArrayListUnmanaged(EntityPoint(Entity)) = .empty;
             defer result_buffer.deinit(self.allocator);
 
             self.entity_spatial.queryRadius(x, y, radius, &result_buffer) catch return buffer[0..0];
@@ -1060,7 +1060,7 @@ pub fn PathfindingEngine(comptime Config: type) type {
 
         /// Get all entities within a rectangle
         pub fn getEntitiesInRect(self: *Self, x: f32, y: f32, w: f32, h: f32, buffer: []Entity) []Entity {
-            var result_buffer: std.ArrayListUnmanaged(EntityPoint(Entity)) = .{};
+            var result_buffer: std.ArrayListUnmanaged(EntityPoint(Entity)) = .empty;
             defer result_buffer.deinit(self.allocator);
 
             self.entity_spatial.queryRect(.{ .x = x, .y = y, .width = w, .height = h }, &result_buffer) catch return buffer[0..0];
@@ -1401,7 +1401,7 @@ pub fn PathfindingEngine(comptime Config: type) type {
         /// For floor-aware lookups, set `opts.max_y_delta` to constrain
         /// which nodes are considered (e.g. only same floor or above).
         pub fn findNearestNodeFiltered(self: *Self, x: f32, y: f32, opts: NearestNodeOptions) !NodeId {
-            var buffer: std.ArrayListUnmanaged(EntityPoint(NodeId)) = .{};
+            var buffer: std.ArrayListUnmanaged(EntityPoint(NodeId)) = .empty;
             defer buffer.deinit(self.allocator);
 
             // Start with a small radius and expand
@@ -1654,7 +1654,7 @@ pub fn PathfindingEngine(comptime Config: type) type {
         /// The returned struct contains all node connections with their distances.
         /// Caller must call deinit() on the returned struct to free memory.
         pub fn getDebugConnectionMatrix(self: *Self) !DebugConnectionMatrix {
-            var entries: std.ArrayListUnmanaged(ConnectionEntry) = .{};
+            var entries: std.ArrayListUnmanaged(ConnectionEntry) = .empty;
             defer entries.deinit(self.allocator);
 
             // Iterate through all edges and get distances from Floyd-Warshall

--- a/src/floyd_warshall_optimized.zig
+++ b/src/floyd_warshall_optimized.zig
@@ -596,7 +596,7 @@ test "FloydWarshallOptimized path reconstruction" {
 
     fw.generate();
 
-    var path = std.ArrayListUnmanaged(u32){};
+    var path = std.ArrayListUnmanaged(u32).empty;
     defer path.deinit(allocator);
 
     try fw.setPathWithMappingUnmanaged(allocator, &path, 10, 40);

--- a/src/quad_tree.zig
+++ b/src/quad_tree.zig
@@ -77,7 +77,7 @@ pub fn QuadTree(comptime T: type) type {
 
         pub fn init(allocator: std.mem.Allocator, boundary: Rectangle) !Self {
             var qt = Self{
-                .nodes = .{},
+                .nodes = .empty,
                 .allocator = allocator,
             };
             try qt.nodes.append(allocator, .{ .boundary = boundary });

--- a/system_tests/single_stair_test.zig
+++ b/system_tests/single_stair_test.zig
@@ -486,7 +486,7 @@ fn runMultiFloorTest(allocator: std.mem.Allocator) !bool {
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}).init;
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/tests/floyd_warshall_optimized_spec.zig
+++ b/tests/floyd_warshall_optimized_spec.zig
@@ -92,7 +92,7 @@ pub const FloydWarshallOptimizedSpec = struct {
         }
 
         test "reconstructs full path" {
-            var path_list = std.ArrayListUnmanaged(u32){};
+            var path_list = std.ArrayListUnmanaged(u32).empty;
             defer path_list.deinit(std.testing.allocator);
 
             try fw.setPathWithMappingUnmanaged(std.testing.allocator, &path_list, 100, 400);

--- a/tests/quad_tree_spec.zig
+++ b/tests/quad_tree_spec.zig
@@ -20,7 +20,7 @@ pub const QuadTreeSpec = struct {
             try expect.toBeTrue(qt.insert(.{ .id = 3, .x = 80, .y = 80 }));
 
             // Query rectangle
-            var buffer: std.ArrayListUnmanaged(quad_tree.EntityPoint(u32)) = .{};
+            var buffer: std.ArrayListUnmanaged(quad_tree.EntityPoint(u32)) = .empty;
             defer buffer.deinit(allocator);
 
             try qt.queryRect(.{ .x = 0, .y = 0, .width = 50, .height = 50 }, &buffer);
@@ -37,7 +37,7 @@ pub const QuadTreeSpec = struct {
             _ = qt.insert(.{ .id = 2, .x = 20, .y = 20 });
             _ = qt.insert(.{ .id = 3, .x = 80, .y = 80 });
 
-            var buffer: std.ArrayListUnmanaged(quad_tree.EntityPoint(u32)) = .{};
+            var buffer: std.ArrayListUnmanaged(quad_tree.EntityPoint(u32)) = .empty;
             defer buffer.deinit(allocator);
 
             try qt.queryRadius(10, 10, 15, &buffer);
@@ -55,7 +55,7 @@ pub const QuadTreeSpec = struct {
 
             try expect.toBeTrue(qt.remove(1));
 
-            var buffer: std.ArrayListUnmanaged(quad_tree.EntityPoint(u32)) = .{};
+            var buffer: std.ArrayListUnmanaged(quad_tree.EntityPoint(u32)) = .empty;
             defer buffer.deinit(allocator);
 
             try qt.queryRect(.{ .x = 0, .y = 0, .width = 50, .height = 50 }, &buffer);
@@ -75,7 +75,7 @@ pub const QuadTreeSpec = struct {
                 _ = qt.insert(.{ .id = @intCast(i), .x = @floatFromInt(i * 10), .y = @floatFromInt(i * 10) });
             }
 
-            var buffer: std.ArrayListUnmanaged(quad_tree.EntityPoint(u32)) = .{};
+            var buffer: std.ArrayListUnmanaged(quad_tree.EntityPoint(u32)) = .empty;
             defer buffer.deinit(allocator);
 
             try qt.queryRect(.{ .x = 0, .y = 0, .width = 100, .height = 100 }, &buffer);

--- a/usage/basic_example.zig
+++ b/usage/basic_example.zig
@@ -27,7 +27,7 @@ const Position = pathfinding.Position;
 const Engine = pathfinding.PathfindingEngine(Config);
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}).init;
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/usage/benchmark_floyd_warshall.zig
+++ b/usage/benchmark_floyd_warshall.zig
@@ -18,8 +18,15 @@ const FloydWarshallParallel = pathfinding.FloydWarshallParallel;
 
 const print = std.debug.print;
 
+/// Returns a monotonic nanosecond timestamp.
+fn nowNs() i128 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(std.c.CLOCK.MONOTONIC, &ts);
+    return @as(i128, ts.sec) * std.time.ns_per_s + @as(i128, ts.nsec);
+}
+
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}).init;
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -83,11 +90,11 @@ fn benchmarkLegacy(allocator: std.mem.Allocator, size: u32) !f64 {
     createDenseGraph(&fw, size);
 
     // Measure generation time
-    var timer = try std.time.Timer.start();
+    const start_ns = nowNs();
 
     fw.generate();
 
-    const elapsed = timer.read();
+    const elapsed = nowNs() - start_ns;
     return @as(f64, @floatFromInt(elapsed)) / std.time.ns_per_ms;
 }
 
@@ -102,11 +109,11 @@ fn benchmarkSimd(allocator: std.mem.Allocator, size: u32) !f64 {
     createDenseGraph(&fw, size);
 
     // Measure generation time
-    var timer = try std.time.Timer.start();
+    const start_ns = nowNs();
 
     fw.generate();
 
-    const elapsed = timer.read();
+    const elapsed = nowNs() - start_ns;
     return @as(f64, @floatFromInt(elapsed)) / std.time.ns_per_ms;
 }
 
@@ -121,11 +128,11 @@ fn benchmarkParallel(allocator: std.mem.Allocator, size: u32) !f64 {
     createDenseGraph(&fw, size);
 
     // Measure generation time
-    var timer = try std.time.Timer.start();
+    const start_ns = nowNs();
 
     fw.generate();
 
-    const elapsed = timer.read();
+    const elapsed = nowNs() - start_ns;
     return @as(f64, @floatFromInt(elapsed)) / std.time.ns_per_ms;
 }
 

--- a/usage/building_example.zig
+++ b/usage/building_example.zig
@@ -17,7 +17,7 @@ const Config = struct {
 const Engine = pathfinding.PathfindingEngine(Config);
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}).init;
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/usage/engine_example.zig
+++ b/usage/engine_example.zig
@@ -41,7 +41,7 @@ fn onPathCompleted(game: *Game, entity: GameEntity, node: pathfinding.NodeId) vo
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}).init;
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/usage/game_example.zig
+++ b/usage/game_example.zig
@@ -27,7 +27,7 @@ const GameState = struct {
     fn init(allocator: std.mem.Allocator) GameState {
         return .{
             .entities = std.AutoHashMap(EntityId, EntityType).init(allocator),
-            .events = .{},
+            .events = .empty,
             .allocator = allocator,
         };
     }
@@ -93,7 +93,7 @@ fn onPathBlocked(game: *GameState, entity: EntityId, node: pathfinding.NodeId) v
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}).init;
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/usage/platformer_example.zig
+++ b/usage/platformer_example.zig
@@ -16,7 +16,7 @@ const Config = struct {
 const Engine = pathfinding.PathfindingEngine(Config);
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}).init;
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/usage/raylib_building_example.zig
+++ b/usage/raylib_building_example.zig
@@ -86,7 +86,7 @@ const COLORS = struct {
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}).init;
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -215,13 +215,13 @@ fn rebuildBuilding(game: *Game) !void {
         y: f32,
         speed: f32,
     };
-    var saved_entities = std.ArrayList(EntityState).init(game.allocator);
-    defer saved_entities.deinit();
+    var saved_entities: std.ArrayList(EntityState) = .empty;
+    defer saved_entities.deinit(game.allocator);
 
     for (0..game.next_entity_id) |i| {
         const entity: u32 = @intCast(i);
         if (game.engine.getPosition(entity)) |pos| {
-            saved_entities.append(.{
+            saved_entities.append(game.allocator, .{
                 .x = pos.x,
                 .y = pos.y,
                 .speed = game.engine.getSpeed(entity) orelse 80.0,

--- a/usage/raylib_example.zig
+++ b/usage/raylib_example.zig
@@ -37,7 +37,7 @@ const Game = struct {
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}).init;
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/usage/single_stair_example.zig
+++ b/usage/single_stair_example.zig
@@ -30,7 +30,7 @@ const GameState = struct {
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}).init;
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 


### PR DESCRIPTION
## Summary
- Bumps `minimum_zig_version` to 0.16.0
- Pin bumps: `raylib_zig` → main (PR #304 merged), `zspec` → apotema fork, `zig_utils` → migration branch
- `GeneralPurposeAllocator` → `DebugAllocator` (10 sites)
- `ArrayListUnmanaged` default-init → `.empty` (~15 sites)
- `PriorityQueue` API: `init` → `initContext`, `.add` → `.push(allocator, …)`, `.removeOrNull` → `.pop`
- `std.time.Timer` → custom `clock_gettime`-based `nowNs()` helper (benchmark only)
- `Compile.linkLibrary` → `.root_module.linkLibrary` in build.zig

## Status
- `zig build`: ✅ PASS
- `zig build test`: ✅ PASS
- `zig build spec`: ✅ PASS (135/135 spec tests)