### PR TITLE
feat: make the package consumable as the 'pathfinder' plugin

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -14,14 +14,28 @@ pub fn build(b: *std.Build) void {
 
     // Main module — navigation layer (Controller + pure engine) at the top level,
     // standalone algorithm core under `.algo`.
+    const module_imports = [_]std.Build.Module.Import{
+        .{ .name = "zig_utils", .module = zig_utils },
+        .{ .name = "labelle-core", .module = core_mod },
+    };
     const pathfinding_module = b.addModule("labelle_pathfinding", .{
         .root_source_file = b.path("src/pathfinding.zig"),
         .target = target,
         .optimize = optimize,
-        .imports = &.{
-            .{ .name = "zig_utils", .module = zig_utils },
-            .{ .name = "labelle-core", .module = core_mod },
-        },
+        .imports = &module_imports,
+    });
+
+    // The labelle assembler consumes this package as the `pathfinder` plugin and
+    // requests the module by the convention name `labelle_<pluginname>` =
+    // `labelle_pathfinder` (build_files.zig). Expose that spelling as an alias of
+    // the same source, so both the plugin path (`labelle_pathfinder`) and the
+    // package-name spelling (`labelle_pathfinding`, used by standalone consumers
+    // + the README) resolve.
+    _ = b.addModule("labelle_pathfinder", .{
+        .root_source_file = b.path("src/pathfinding.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &module_imports,
     });
 
     // Unit tests (refAllDecls over the nav layer + algorithm core).

--- a/build.zig
+++ b/build.zig
@@ -14,29 +14,24 @@ pub fn build(b: *std.Build) void {
 
     // Main module — navigation layer (Controller + pure engine) at the top level,
     // standalone algorithm core under `.algo`.
-    const module_imports = [_]std.Build.Module.Import{
-        .{ .name = "zig_utils", .module = zig_utils },
-        .{ .name = "labelle-core", .module = core_mod },
-    };
     const pathfinding_module = b.addModule("labelle_pathfinding", .{
         .root_source_file = b.path("src/pathfinding.zig"),
         .target = target,
         .optimize = optimize,
-        .imports = &module_imports,
+        .imports = &.{
+            .{ .name = "zig_utils", .module = zig_utils },
+            .{ .name = "labelle-core", .module = core_mod },
+        },
     });
 
     // The labelle assembler consumes this package as the `pathfinder` plugin and
     // requests the module by the convention name `labelle_<pluginname>` =
-    // `labelle_pathfinder` (build_files.zig). Expose that spelling as an alias of
-    // the same source, so both the plugin path (`labelle_pathfinder`) and the
-    // package-name spelling (`labelle_pathfinding`, used by standalone consumers
-    // + the README) resolve.
-    _ = b.addModule("labelle_pathfinder", .{
-        .root_source_file = b.path("src/pathfinding.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &module_imports,
-    });
+    // `labelle_pathfinder` (build_files.zig). Register the SAME module instance
+    // under that spelling — not a second addModule, which would be a distinct
+    // module (breaking type identity if a consumer mixed the two names, and
+    // compiling the source twice). Both `labelle_pathfinder` and the package-name
+    // spelling `labelle_pathfinding` now resolve to one module.
+    b.modules.put(b.allocator, "labelle_pathfinder", pathfinding_module) catch @panic("OOM");
 
     // Unit tests (refAllDecls over the nav layer + algorithm core).
     const unit_tests = b.addTest(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -22,6 +22,7 @@
     .paths = .{
         "build.zig",
         "build.zig.zon",
+        "plugin.labelle",
         "src",
     },
 }

--- a/plugin.labelle
+++ b/plugin.labelle
@@ -1,0 +1,16 @@
+// Pathfinder plugin manifest.
+//
+// This package provides the labelle-engine **navigation plugin** named
+// `pathfinder` (matching the consuming game's `.plugins` entry and its
+// `@import("pathfinder")` call sites). The plugin's Controller is discovered by
+// the assembler via a comptime `@hasDecl(mod, "Controller")` scan of the root
+// module (`src/pathfinding.zig` re-exports `Controller`), not by this manifest.
+//
+// No convention dirs: the per-frame `advance` is driven by a game-side dispatch
+// script, so this plugin ships no scripts of its own. The manifest's presence
+// opts into the `manifest_version` handshake (RFC-plugin-controllers §2).
+.{
+    .name = "pathfinder",
+    .manifest_version = 1,
+    .convention_dirs = .{},
+}

--- a/src/pathfinding.zig
+++ b/src/pathfinding.zig
@@ -66,6 +66,10 @@ pub const MovementStair = nav.MovementStair;
 pub const ClosestMovementNode = nav.ClosestMovementNode;
 pub const MovementTargetWith = nav.MovementTargetWith;
 pub const NavigationIntentWith = nav.NavigationIntentWith;
+// The `Components` aggregator the assembler scans to register the plugin's
+// components (MovementNode / MovementStair / ClosestMovementNode /
+// ControllerState) into the ComponentRegistry.
+pub const Components = nav.Components;
 
 // Paths, hooks, gizmos, scalar types.
 pub const MovementPath = nav.MovementPath;


### PR DESCRIPTION
Follow-up to #46 — the three pieces needed for a labelle-engine game to consume this package as its `pathfinder` navigation plugin (verified end-to-end against Flying Platform: builds + runs identically, workers navigate, zero errors).

- **`plugin.labelle`** manifest (plugin name `pathfinder`, matching the consuming game's `.plugins` entry). Added to `build.zig.zon` paths.
- **Module alias `labelle_pathfinder`** — the assembler requests a plugin's module by the convention `labelle_<pluginname>`; our module is named `labelle_pathfinding` (repo spelling), so expose `labelle_pathfinder` as an alias of the same source. Both resolve.
- **`Components` aggregator** re-exported at the package root, so the assembler registers the plugin's components (`MovementNode`/`MovementStair`/`ClosestMovementNode`/`ControllerState`) into the ComponentRegistry.

Tests: 52/52 still pass.