### PR TITLE
feat(nav): first-class reachable() query + query/command split (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,64 @@ if (try astar.findPathWithMapping(100, 200, &path)) |cost| {
 }
 ```
 
+## Querying the graph (navigation Controller)
+
+When you use this package as the `pathfinder` plugin in a labelle-engine
+game, the ECS-integrated `Controller` exposes a clean **query** surface,
+split from its navigation **commands**. This is the agent-facing contract
+other packs consume — the pathfinder is the canonical published
+*query-pack* under the Packs model. Ask it three things: *how far is A
+from B?*, *is there a path?*, and *what's the nearest node?*
+
+**Queries** (read-only — safe to call from scoring / planning loops):
+
+| Query | Returns | Meaning |
+|-------|---------|---------|
+| `distance(game, a, b)` | `?f32` | Graph path length between two entities. `null` = no path. |
+| `reachable(game, a, b)` | `bool` | Is there *any* path between two entities? |
+| `reachableNode(game, entity, node)` | `bool` | Is a specific node id reachable from `entity`? |
+| `reachablePosition(game, entity, pos)` | `bool` | Is the node nearest `pos` reachable from `entity`? |
+| `nearestNode(game, pos)` | `?NodeId` | Nearest movement node to a world point (alias of `findClosestNode`). |
+| `nodeCount(game)` | `u32` | Number of registered graph nodes (0 = pre-graph). |
+| `graphEpoch(game)` | `u64` | Bumps every rebuild — use to invalidate cached node lookups. |
+
+**Commands** (mutate state / start work): `navigate`, `cancel`,
+`removeNode`, `rebuildGraph`, `advance` (the per-frame plugin tick).
+
+### What `null` / `false` mean
+
+Both the "no path" and "pre-graph" cases collapse to the same negative
+answer on purpose:
+
+- **No path** — the graph is built but no route connects the two nodes.
+- **Pre-graph** — the graph has no nodes yet (controller setup pending,
+  or between scenes). `nodeCount(game) == 0`.
+
+A caller asking *"can I get there?"* gets `false`/`null` either way. If
+you need to distinguish, check `nodeCount(game)` (or watch `graphEpoch`
+and retry once it advances). A positive answer always means a real route
+exists in the current graph.
+
+```zig
+const pf = @import("labelle_pathfinding");
+
+// Distance query — null when unreachable.
+if (pf.Controller.distance(game, worker, workstation)) |d| {
+    // ... score by d ...
+}
+
+// Reachability query — the first-class replacement for `distance(...) != null`.
+if (pf.Controller.reachable(game, worker, workstation)) {
+    // ... assign the job ...
+}
+
+// "Filter reachable nodes, then score by Euclidean to a target."
+for (candidate_nodes) |node| {
+    if (!pf.Controller.reachableNode(game, guard, node)) continue;
+    // ... keep the reachable candidate, score it ...
+}
+```
+
 ## Algorithm Selection Guide
 
 | Use Case | Recommended |

--- a/src/nav/controller.zig
+++ b/src/nav/controller.zig
@@ -378,6 +378,40 @@ pub const Controller = struct {
     // ------------------------------------------------------------------
     // Public API (re-exported to game scripts as `pathfinder.Controller.*`)
     // ------------------------------------------------------------------
+    //
+    // The surface splits cleanly into two halves — this is the
+    // agent-facing contract other packs consume (the pathfinder is the
+    // canonical published *query-pack* under the Packs model; see
+    // labelle-engine#651 / FP RFC-packs.md):
+    //
+    //   QUERIES (read-only, no side effects) — safe to call from
+    //   scoring/planning loops:
+    //     * distance(a, b)          → `?f32`  path length, null = no path
+    //     * reachable(a, b)         → `bool`  is there any path A→B?
+    //     * reachableNode(e, node)  → `bool`  path from e to a node id?
+    //     * reachablePosition(e, p) → `bool`  path from e to a world point?
+    //     * nearestNode(pos)        → `?NodeId` (alias of findClosestNode)
+    //     * findClosestNode(pos)    → `?NodeId`
+    //     * nodeCount()             → `u32`
+    //     * graphEpoch()            → `u64`
+    //     * isNavigating(e)         → `bool`
+    //
+    //   COMMANDS (mutate state / start work):
+    //     * navigate(e, target, src)
+    //     * cancel(e)
+    //     * removeNode(node)
+    //     * rebuildGraph()
+    //     * advance(dt)             (plugin tick — not called by games)
+    //
+    // Return-value contract for the reachability/distance queries:
+    //   * `null` / `false` == "no path" when the graph is built but no
+    //     route connects the two nodes, OR "pre-graph" when the graph
+    //     has no nodes yet (setup pending / between scenes). Both cases
+    //     collapse to the same negative answer on purpose — a caller
+    //     asking "can I get there?" gets `false` either way and should
+    //     retry once `graphEpoch()` advances if it needs to distinguish.
+    //   * A positive answer (`Some`/`true`) always means a real route
+    //     exists in the current graph.
 
     /// Request navigation for `entity` towards `target` (world position).
     ///
@@ -576,6 +610,64 @@ pub const Controller = struct {
         const d = st.pf.distance(from_node, to_node);
         if (d == types.INF) return null;
         return d;
+    }
+
+    /// QUERY. Is there any graph path between two game entities, via
+    /// each entity's nearest movement node? First-class replacement for
+    /// the `distance(a, b) != null` idiom callers used to sprinkle at
+    /// every reachability check (FP `entityDistance`, the guard-system
+    /// reachability filter — see FP `movement.md`).
+    ///
+    /// Same O(1) Floyd-Warshall matrix cost as `distance`; this
+    /// single-sources the semantics through that one function so
+    /// `reachable(a, b)` and `distance(a, b) != null` can never drift.
+    ///
+    /// Returns `false` when the controller isn't set up, the graph has
+    /// no nodes yet (pre-graph), either entity has no nearby node
+    /// (Y-filtered / beyond `MAX_NODE_SNAP_DISTANCE`), or no path
+    /// connects them. See the query-contract note above for what
+    /// `false` means.
+    pub fn reachable(game: anytype, from_entity: anytype, to_entity: anytype) bool {
+        return distance(game, from_entity, to_entity) != null;
+    }
+
+    /// QUERY. Is a specific `node_id` reachable from `entity`'s nearest
+    /// movement node? The "filter reachable nodes, then score by
+    /// Euclidean to a target" pattern (FP `14_guard_system`) iterates
+    /// candidate nodes and keeps the reachable ones with this.
+    ///
+    /// Returns `false` pre-graph, when the controller isn't set up,
+    /// when `entity` has no nearby node, when `node_id` is out of range
+    /// or tombstoned, or when no path connects them.
+    pub fn reachableNode(game: anytype, entity: anytype, node_id: NodeId) bool {
+        const st = findState(game) orelse return false;
+        const pos = game.getWorldPosition(entity);
+        const entity_id: u64 = @intCast(entity);
+        const from_node = findNearestNodeForEntity(st, entity_id, pos.x, pos.y) orelse return false;
+        return nodesReachable(st, from_node, node_id);
+    }
+
+    /// QUERY. Is the movement node nearest to a world `position`
+    /// reachable from `entity`? Convenience wrapper over `reachableNode`
+    /// for callers holding a target `Position` rather than a node id.
+    ///
+    /// Returns `false` pre-graph, when the controller isn't set up, when
+    /// either side has no nearby node, or when no path connects them.
+    pub fn reachablePosition(game: anytype, entity: anytype, position: Position) bool {
+        const st = findState(game) orelse return false;
+        const to_node = findNearestNodeInState(st, position.x, position.y) orelse return false;
+        const pos = game.getWorldPosition(entity);
+        const entity_id: u64 = @intCast(entity);
+        const from_node = findNearestNodeForEntity(st, entity_id, pos.x, pos.y) orelse return false;
+        return nodesReachable(st, from_node, to_node);
+    }
+
+    /// QUERY. Alias of `findClosestNode` — the movement node nearest to
+    /// (and at or below) `position`, or `null` if none qualifies. Named
+    /// to match the query-surface vocabulary (`nearestNode`) other packs
+    /// address the pathfinder with.
+    pub fn nearestNode(game: anytype, position: Position) ?NodeId {
+        return findClosestNode(game, position);
     }
 
     /// Resolve the world-space position to use as a `NavigationIntent`'s
@@ -1017,6 +1109,31 @@ pub fn findNearestNodeInState(st: *State, x: f32, y: f32) ?NodeId {
     // can't silently route through a far-away node.
     if (best_dist > MAX_NODE_SNAP_DISTANCE) return null;
     return best;
+}
+
+/// Node → node graph reachability with removed / out-of-range guards.
+/// Single-sources the reachability semantics shared by
+/// `Controller.reachable*`: bottoms out in the same Floyd-Warshall
+/// matrix lookup as `distance` (`isReachable == distance != INF`), so
+/// the two can never disagree.
+///
+/// Returns `false` pre-graph (no node slots), for a tombstoned or
+/// out-of-range `from`/`to`, and when no route connects the pair.
+/// Guards the removed/OOB cases up front because the underlying
+/// `pf.isReachable` assumes both ids map to live matrix entries —
+/// `Controller.distance` only ever feeds it ids resolved by
+/// `findNearestNode*` (never removed), but the node-id–taking
+/// `reachableNode` accepts caller-supplied ids that may be stale.
+///
+/// Exposed `pub` so the reachability tests can exercise it against a
+/// synthetic `State` without a live game/ECS backend, mirroring how
+/// `findNearestNodeInState` is tested in `controller_snap_test.zig`.
+pub fn nodesReachable(st: *State, from: NodeId, to: NodeId) bool {
+    const slots = st.pf.graph.totalSlots();
+    if (slots == 0) return false;
+    if (from >= slots or to >= slots) return false;
+    if (st.pf.graph.isRemoved(from) or st.pf.graph.isRemoved(to)) return false;
+    return st.pf.isReachable(from, to);
 }
 
 /// Thin bridge exposing `getEntityPosition` / `moveEntity` to the

--- a/tests/nav/reachable_test.zig
+++ b/tests/nav/reachable_test.zig
@@ -1,0 +1,103 @@
+//! Coverage for the first-class reachability query surface added for
+//! issue #48 (Packs query-pack exemplar). Exercises the State-level
+//! `nodesReachable` helper that single-sources the semantics behind
+//! `Controller.reachable` / `reachableNode` / `reachablePosition`.
+//!
+//! The Controller's game-facing methods (`reachable(game, a, b)`, …)
+//! need a live ECS backend to resolve entities → nodes, so they're not
+//! unit-tested here; `Controller.reachable` is by construction
+//! `distance(a, b) != null`, and both `distance` and `nodesReachable`
+//! bottom out in the SAME `pf.isReachable` / `pf.distance` matrix
+//! lookup — the consistency asserted below is what guarantees the
+//! entity-level wrappers agree with `distance`.
+
+const std = @import("std");
+const pathfinder = @import("pathfinder");
+
+const State = pathfinder.controller.State;
+const nodesReachable = pathfinder.controller.nodesReachable;
+const INF = pathfinder.INF;
+
+/// Two connected stair nodes on X=100 (y=100/200, dist 100 < the
+/// State's 200-px vertical cap) plus one isolated node far off on its
+/// own axis. Node ids: 0 and 1 connected; 2 disconnected.
+fn connectedPairPlusIsolated() !State {
+    var st = State.init(std.testing.allocator);
+    _ = try st.pf.addNode(.{ .x = 100, .y = 100 }, true); // node 0 (stair)
+    _ = try st.pf.addNode(.{ .x = 100, .y = 200 }, true); // node 1 (stair)
+    _ = try st.pf.addNode(.{ .x = 500, .y = 500 }, true); // node 2 (isolated)
+    return st;
+}
+
+test "nodesReachable: connected pair is reachable" {
+    var st = try connectedPairPlusIsolated();
+    defer st.deinit();
+
+    try std.testing.expect(nodesReachable(&st, 0, 1));
+    // Symmetric — the graph is bidirectional.
+    try std.testing.expect(nodesReachable(&st, 1, 0));
+}
+
+test "nodesReachable: disconnected pair is not reachable" {
+    var st = try connectedPairPlusIsolated();
+    defer st.deinit();
+
+    try std.testing.expect(!nodesReachable(&st, 0, 2));
+    try std.testing.expect(!nodesReachable(&st, 2, 1));
+}
+
+test "nodesReachable: pre-graph (no nodes) is false" {
+    var st = State.init(std.testing.allocator);
+    defer st.deinit();
+
+    // Empty graph — the pre-graph negative answer, regardless of ids.
+    try std.testing.expect(!nodesReachable(&st, 0, 0));
+    try std.testing.expect(!nodesReachable(&st, 0, 1));
+}
+
+test "nodesReachable: a node is reachable from itself" {
+    var st = try connectedPairPlusIsolated();
+    defer st.deinit();
+
+    // Even the isolated node reaches itself (distance 0).
+    try std.testing.expect(nodesReachable(&st, 2, 2));
+}
+
+test "nodesReachable: out-of-range node id is false" {
+    var st = try connectedPairPlusIsolated();
+    defer st.deinit();
+
+    // Only 3 slots (ids 0..2) — id 99 is past totalSlots().
+    try std.testing.expect(!nodesReachable(&st, 0, 99));
+    try std.testing.expect(!nodesReachable(&st, 99, 0));
+}
+
+test "nodesReachable: tombstoned node id is false" {
+    var st = try connectedPairPlusIsolated();
+    defer st.deinit();
+
+    // Reachable before removal…
+    try std.testing.expect(nodesReachable(&st, 0, 1));
+    // …tombstone node 1 and the guard rejects it (no matrix panic).
+    st.pf.removeNode(1);
+    try std.testing.expect(!nodesReachable(&st, 0, 1));
+    try std.testing.expect(!nodesReachable(&st, 1, 0));
+}
+
+test "nodesReachable agrees with distance() != INF for every pair" {
+    var st = try connectedPairPlusIsolated();
+    defer st.deinit();
+
+    // The load-bearing consistency check: `reachable` must always
+    // mean exactly `distance != null`. Since both go through the same
+    // pf matrix, assert it holds for the full pair space.
+    const slots = st.pf.graph.totalSlots();
+    var a: u32 = 0;
+    while (a < slots) : (a += 1) {
+        var b: u32 = 0;
+        while (b < slots) : (b += 1) {
+            const via_distance = st.pf.distance(a, b) != INF;
+            try std.testing.expectEqual(via_distance, nodesReachable(&st, a, b));
+        }
+    }
+}

--- a/tests/nav/root.zig
+++ b/tests/nav/root.zig
@@ -6,4 +6,5 @@ test {
     _ = @import("engine_test.zig");
     _ = @import("controller_cache_test.zig");
     _ = @import("controller_snap_test.zig");
+    _ = @import("reachable_test.zig");
 }


### PR DESCRIPTION
## What

Adds a clean, agent-facing **query** surface to the navigation `Controller`, split explicitly from its navigation **commands**. Pathfinding is the canonical published **query-pack** under the Packs model — other packs `depends_on = .{ "pathfinding" }` and ask it *"how far is A from B?"* and *"is there a path?"*. This makes those first-class instead of the `distance(a, b) != null` idiom consumers roll by hand (FP `entityDistance`, the guard-system reachability filter documented in FP `movement.md`).

**Additive only** — no existing signatures change. Interface-clarity, not a perf change (`reachable` is the same O(1) Floyd-Warshall matrix lookup as `distance`).

## Queries added (`Controller`)

| Signature | Meaning |
|-----------|---------|
| `reachable(game, a, b) bool` | Is there any path between two entities? Single-sources `distance(a, b) != null`. |
| `reachableNode(game, entity, node_id: NodeId) bool` | Path from an entity to a specific node id — the "filter reachable nodes, then score by Euclidean to target" pattern in FP `14_guard_system`. Guards tombstoned / out-of-range ids. |
| `reachablePosition(game, entity, position: Position) bool` | Reachability to the node nearest a world point. |
| `nearestNode(game, position: Position) ?NodeId` | Alias of `findClosestNode`, matching the query-surface vocabulary. |

### Internals
- `controller.nodesReachable(st, from, to) bool` — shared, `pub`, testable-without-ECS helper that bottoms out in the same `pf.isReachable` / `pf.distance` matrix lookup, guarding removed / out-of-range ids up front (the node-id–taking `reachableNode` accepts caller-supplied ids that may be stale).

## Query vs command split (documented contract)

- **Queries:** `distance`, `reachable`, `reachableNode`, `reachablePosition`, `nearestNode`/`findClosestNode`, `nodeCount`, `graphEpoch`, `isNavigating`.
- **Commands:** `navigate`, `cancel`, `removeNode`, `rebuildGraph`, `advance`.

Spelled out in a doc block on the `Controller` public API and a new README **"Querying the graph"** section, including what `null` / `false` mean: **no path** (graph built, no route) and **pre-graph** (no nodes yet) collapse to the same negative answer on purpose; check `nodeCount`/`graphEpoch` to distinguish.

> Note: the issue's command list mentions `requestRepath`, but no such method exists on the `Controller` today — documented the real command surface rather than inventing it. Flagging in case it's expected as a follow-up.

## Tests

`tests/nav/reachable_test.zig` (runs under `zig build spec`): reachable pair → true, disconnected pair → false, pre-graph → false, self-reachability, out-of-range id → false, tombstoned id → false, and a full-pair-space consistency check asserting `nodesReachable == (distance != INF)`.

`zig build`, `zig build test`, `zig build spec` all pass (59/59 spec tests).

## Deferred (FP follow-up, tracked in #48)

Migrating FP `entityDistance` + the guard reachability filter to `reachable()` and updating `movement.md` to point at the first-class query.

Closes #48
Umbrella: labelle-toolkit/labelle-engine#651