### PR TITLE
fix: gate plugin-event emits behind comptime GameEvents check (#52)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,10 @@ script calling `Controller.advance(game, dt)`.
   starting anew, so failed retargets can't be resurrected by the rehydration
   sweep.
 - **Events are sparse** (settles, rebuilds, tombstones) — continuous state is
-  behind the queries. The plugin never subscribes to game events.
+  behind the queries. The plugin never subscribes to game events. All emits go
+  through the comptime-gated `emitGameEvent` helper (controller.zig, #52) —
+  never `game.emit(.{ .pathfinder__… })` raw union literals, which defeat the
+  assembler's event-consumption elision (assembler#630).
 - **World positions** (`getWorldPosition`) everywhere positions are compared —
   parented entities (storages under rooms) are meaningless in local coords.
 

--- a/src/nav/controller.zig
+++ b/src/nav/controller.zig
@@ -1034,7 +1034,7 @@ pub const Controller = struct {
     pub fn removeNode(game: anytype, node_id: NodeId) void {
         const st = findState(game) orelse return;
         st.pf.removeNode(node_id);
-        game.emit(.{ .pathfinder__node_removed = .{ .node_id = node_id } });
+        emitGameEvent(game, "pathfinder__node_removed", .{ .node_id = node_id });
     }
 
     /// Per-frame advancement of in-flight navigations.
@@ -1166,7 +1166,7 @@ pub const Controller = struct {
         // to. The event is the push twin of the `graphEpoch()` poll
         // (v4); the plugin's own CMN sweep keys off the same counter.
         st.graph_epoch += 1;
-        game.emit(.{ .pathfinder__graph_rebuilt = .{ .epoch = st.graph_epoch } });
+        emitGameEvent(game, "pathfinder__graph_rebuilt", .{ .epoch = st.graph_epoch });
     }
 
     fn countMovementNodes(game: anytype) u32 {
@@ -1553,10 +1553,10 @@ fn settleArrival(game: anytype, st: *State, entity_id: u64, goal_node: ?NodeId) 
         ecs.removeComponent(entity, ClosestMovementNode);
     }
 
-    game.emit(.{ .pathfinder__arrived = .{
+    emitGameEvent(game, "pathfinder__arrived", .{
         .entity = entity_id,
         .node_entity = node_entity,
-    } });
+    });
 }
 
 /// Settle a failed walk: drop the persisted order and announce. The
@@ -1570,10 +1570,10 @@ fn settleFailed(game: anytype, entity_id: u64, reason: FailReason) void {
     if (ecs.entityExists(entity)) {
         ecs.removeComponent(entity, Navigating);
     }
-    game.emit(.{ .pathfinder__navigation_failed = .{
+    emitGameEvent(game, "pathfinder__navigation_failed", .{
         .entity = entity_id,
         .reason = reason,
-    } });
+    });
 }
 
 /// Node → node graph reachability with removed / out-of-range guards.
@@ -1650,4 +1650,182 @@ fn GameCtx(comptime GameType: type) type {
             self.game.setPosition(entity, .{ .x = pos.x + dx, .y = pos.y + dy });
         }
     };
+}
+
+// ── Gated game-event emission (#52) ─────────────────────────────────────────
+
+/// Emit a `pathfinder__*` game event through a comptime gate instead of
+/// a raw union literal.
+///
+/// Why the indirection: `game.emit(.{ .pathfinder__arrived = … })` is a
+/// hard compile-time reference to that `GameEvents` variant. Under the
+/// assembler's consumption filter (assembler#630, ≥0.93.0) events with
+/// no subscriber are elided from the generated union — an ungated emit
+/// site then fails to compile, and the 0.93.1 safety net can only
+/// respond by force-keeping the event, which defeats the elision
+/// entirely (the payload is built and buffered for nobody). Same
+/// gated-emit contract box2d and the engine follow.
+///
+/// The gate: when the game's `GameEvents` is a union AND declares the
+/// requested variant tag, build the typed payload field-by-field
+/// (widening/narrowing ints with `@intCast`, filling omitted fields
+/// from their declared defaults, `@compileError` on a payload field the
+/// variant doesn't declare AND on a missing required field) and forward
+/// to `game.emit`. Otherwise the entire body folds to a no-op — safe
+/// for `GameEvents = void` builds, for games that never consume a given
+/// pathfinder event, and for synthetic test games with no `GameEvents`
+/// at all. Both the typed path and every no-op shape are unit-tested
+/// below ("emitGameEvent …" tests).
+inline fn emitGameEvent(game: anytype, comptime tag: []const u8, payload: anytype) void {
+    const Game = @TypeOf(game.*);
+    const should_emit = comptime blk: {
+        if (!@hasDecl(Game, "GameEvents")) break :blk false;
+        const GameEvents = Game.GameEvents;
+        const ev_info = @typeInfo(GameEvents);
+        if (ev_info != .@"union") break :blk false;
+        break :blk @hasField(GameEvents, tag);
+    };
+    if (comptime !should_emit) return;
+    const GameEvents = Game.GameEvents;
+    const Payload_t = @FieldType(GameEvents, tag);
+    var typed: Payload_t = undefined;
+    // Reject unknown payload fields up front: the mapping loop below
+    // iterates the *target* variant's fields, so a typo'd payload field
+    // (`.node_idd = …`) would otherwise be silently dropped — and a
+    // defaulted target field would mask the loss entirely.
+    inline for (comptime std.meta.fields(@TypeOf(payload))) |pf| {
+        if (comptime !@hasField(Payload_t, pf.name)) {
+            @compileError("emitGameEvent: unknown payload field '" ++ pf.name ++ "' for variant '" ++ tag ++ "'");
+        }
+    }
+    const fields = comptime std.meta.fields(Payload_t);
+    inline for (fields) |f| {
+        if (comptime @hasField(@TypeOf(payload), f.name)) {
+            const src_val = @field(payload, f.name);
+            const SrcT = @TypeOf(src_val);
+            if (comptime @typeInfo(f.type) == .int and @typeInfo(SrcT) == .int) {
+                @field(typed, f.name) = @intCast(src_val);
+            } else {
+                @field(typed, f.name) = src_val;
+            }
+        } else if (comptime f.default_value_ptr != null) {
+            @field(typed, f.name) = @as(*const f.type, @ptrCast(@alignCast(f.default_value_ptr.?))).*;
+        } else {
+            @compileError("emitGameEvent: missing field '" ++ f.name ++ "' for variant '" ++ tag ++ "'");
+        }
+    }
+    game.emit(@unionInit(GameEvents, tag, typed));
+}
+
+// ── emitGameEvent tests ──
+//
+// Synthetic games exercising both branches of the comptime gate: the
+// typed emit (field mapping, @intCast widening, default filling) and
+// every no-op shape (missing tag, void / non-union GameEvents, no
+// GameEvents decl at all). The @compileError branches — a missing
+// required field and an unknown payload field — are compile-time
+// failures by design and can't be runtime-tested. This repo
+// deliberately has no mock game (see CLAUDE.md), but these games mock
+// only the `GameEvents`/`emit` sliver of the contract, which is
+// exactly the surface under test.
+
+/// A game whose GameEvents union declares pathfinder tags.
+/// `pathfinder__arrived` uses u64 entity fields to prove the @intCast
+/// widening; `pathfinder__graph_rebuilt` carries a defaulted field the
+/// emit-site payload omits.
+const EmitRecordingGame = struct {
+    // `pub` on purpose: real games export GameEvents for cross-module
+    // access — mirror the production contract.
+    pub const GameEvents = union(enum) {
+        pathfinder__arrived: struct { entity: u64, node_entity: u64 },
+        pathfinder__graph_rebuilt: struct {
+            epoch: u64,
+            extra: f32 = 99.5,
+        },
+    };
+
+    last: ?GameEvents = null,
+    count: usize = 0,
+
+    pub fn emit(self: *@This(), event: GameEvents) void {
+        self.last = event;
+        self.count += 1;
+    }
+};
+
+test "emitGameEvent builds the typed payload and widens int fields" {
+    var game = EmitRecordingGame{};
+    emitGameEvent(&game, "pathfinder__arrived", .{
+        .entity = @as(u32, 7),
+        .node_entity = @as(u32, 42),
+    });
+    try std.testing.expectEqual(@as(usize, 1), game.count);
+    switch (game.last.?) {
+        .pathfinder__arrived => |p| {
+            try std.testing.expectEqual(@as(u64, 7), p.entity);
+            try std.testing.expectEqual(@as(u64, 42), p.node_entity);
+        },
+        else => return error.TestExpectedArrived,
+    }
+}
+
+test "emitGameEvent fills omitted fields from their declared defaults" {
+    var game = EmitRecordingGame{};
+    emitGameEvent(&game, "pathfinder__graph_rebuilt", .{
+        .epoch = @as(u64, 3),
+    });
+    try std.testing.expectEqual(@as(usize, 1), game.count);
+    switch (game.last.?) {
+        .pathfinder__graph_rebuilt => |p| {
+            try std.testing.expectEqual(@as(u64, 3), p.epoch);
+            try std.testing.expectEqual(@as(f32, 99.5), p.extra);
+        },
+        else => return error.TestExpectedGraphRebuilt,
+    }
+}
+
+test "emitGameEvent no-ops when the union lacks the requested tag" {
+    // The consumption-filter case this whole helper exists for: the
+    // game consumes `arrived` but the assembler elided `node_removed`.
+    var game = EmitRecordingGame{};
+    emitGameEvent(&game, "pathfinder__node_removed", .{
+        .node_id = @as(u32, 5),
+    });
+    try std.testing.expectEqual(@as(usize, 0), game.count);
+    try std.testing.expect(game.last == null);
+}
+
+test "emitGameEvent no-ops for void and non-union GameEvents" {
+    // Compiling IS the assertion here: if the gate wrongly fired for
+    // these shapes, `@FieldType(void, tag)` / the absent typed-union
+    // path would be a compile error. There is no meaningful runtime
+    // state to observe — the genuinely observable no-op (a missing tag
+    // in a real union) is the test above.
+    const VoidGame = struct {
+        pub const GameEvents = void;
+    };
+    var void_game = VoidGame{};
+    emitGameEvent(&void_game, "pathfinder__arrived", .{
+        .entity = @as(u32, 1),
+        .node_entity = @as(u32, 2),
+    });
+
+    const StructGame = struct {
+        pub const GameEvents = struct {};
+    };
+    var struct_game = StructGame{};
+    emitGameEvent(&struct_game, "pathfinder__arrived", .{
+        .entity = @as(u32, 1),
+        .node_entity = @as(u32, 2),
+    });
+}
+
+test "emitGameEvent no-ops when the game has no GameEvents decl" {
+    // Same contract: compiling is the assertion.
+    const BareGame = struct {};
+    var game = BareGame{};
+    emitGameEvent(&game, "pathfinder__arrived", .{
+        .entity = @as(u32, 1),
+        .node_entity = @as(u32, 2),
+    });
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -103,3 +103,14 @@ pub const FloydWarshall = pathfinding.FloydWarshall;
 
 // Algorithm core (standalone).
 pub const algo = pathfinding.algo;
+
+// Pull the package's test tree into the unit-test build. The build's
+// test root is THIS file (build.zig `unit_tests`), and Zig only
+// collects tests from files referenced inside a collected test block —
+// the decl re-exports above analyze `pathfinding.zig` but do not
+// collect its `test { refAllDecls(nav); … }` chain. Without this block
+// `zig build test` compiles and runs zero tests (found while adding
+// the emitGameEvent tests for #52).
+test {
+    _ = pathfinding;
+}


### PR DESCRIPTION
Closes #52.

## Sites changed

All four `pathfinder__*` emit sites — the complete set of `game.emit` calls in the package (verified by grep; the `Dispatcher.emit` calls in the algo core are the internal hook system, not game events) — now route through a comptime-gated helper instead of raw anonymous union literals:

| Site (`src/nav/controller.zig`) | Event |
|---|---|
| `Controller.removeNode` (~1037) | `pathfinder__node_removed` |
| `maybeRebuildGraph` (~1169) | `pathfinder__graph_rebuilt` |
| `settleArrival` (~1556) | `pathfinder__arrived` |
| `settleFailed` (~1573) | `pathfinder__navigation_failed` |

The `Events` decl stays inline in the literal `src/root.zig` (assembler AST-walk contract, RFC-pathfinder-consolidation §8.9) — untouched.

## Helper design

`emitGameEvent(game, comptime tag, payload)` mirrors labelle-box2d's reference implementation including the box2d#14 hardening:

- comptime gate: `@hasDecl(Game, "GameEvents")` + union `@typeInfo` check + `@hasField(GameEvents, tag)` — an absent variant folds the whole body to a no-op, so the assembler's consumption filter (assembler#630) can elide unconsumed pathfinder events with zero cost at the emit sites;
- typed payload built field-by-field against the *game's* variant type: `@intCast` widening/narrowing for int fields, omitted fields filled from declared defaults;
- `@compileError` on both an **unknown** payload field (typo protection — the mapping loop iterates target fields, so a typo would otherwise be silently dropped) and a **missing** required field.

## Tests

Mirrors box2d#14 coverage — synthetic recording game for the typed path (field mapping, u32→u64 widening, default filling) and every no-op shape (missing tag, `GameEvents = void`, non-union `GameEvents`, no `GameEvents` decl).

**Found while wiring them in: `zig build test` was collecting ZERO tests.** The unit-test root is `src/root.zig`, which never referenced `pathfinding.zig`'s `test { refAllDecls(nav); … }` chain — decl re-exports analyze the file but don't collect its tests. Added the test-tree reference block; the target now runs 11 tests (5 new + the previously-uncollected algo-core tests), verified by deliberate-failure probe. `zig build spec` (zspec nav suite) green throughout.

## FP verification (flying-platform, branch `chore/assembler-0.93.0`, assembler 0.93.0)

Throwaway `local:` pin of this branch in `project.labelle`, `labelle generate` + `labelle build`:

- generated `.labelle/bgfx_desktop/main.zig` has `// elided (no consumer): pathfinder__navigation_failed` and `// elided (no consumer): pathfinder__graph_rebuilt` with **no force-keep annotation**; `pathfinder__arrived` and `pathfinder__node_removed` (both consumed) remain in `PluginEvents`;
- `labelle build` → `build ok`.

Control with the stock 4.0.1 pin under the same assembler reproduces the issue exactly:

```
controller.zig:1169: error: no field named 'pathfinder__graph_rebuilt' in union …
controller.zig:1573: error: no field named 'pathfinder__navigation_failed' in union …
```

(FP working tree restored byte-identical afterwards; nothing committed there.)

## Release

Recommend **patch 4.0.2** — no API surface change, emit sites are behavior-identical for games that consume the events.

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-pathfinding/pr/53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787001078&installation_id=146340424&pr_number=53&repository=labelle-toolkit%2Flabelle-pathfinding&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-pathfinding%2Fpull%2F53&signature=c8e13ea060681ba271f76b5df24a62e55aad3a5ce9cfdc9fad5b7f22c74228e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->