### PR TITLE
chore: synthetic tags in emitGameEvent tests (assembler#636 convention)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,10 @@ script calling `Controller.advance(game, dt)`.
   behind the queries. The plugin never subscribes to game events. All emits go
   through the comptime-gated `emitGameEvent` helper (controller.zig, #52) —
   never `game.emit(.{ .pathfinder__… })` raw union literals, which defeat the
-  assembler's event-consumption elision (assembler#630).
+  assembler's event-consumption elision (assembler#630). Test code must use
+  synthetic tags (`prov__ev`), not real ones — a dot-prefixed real tag
+  anywhere in plugin source force-keeps the event in every consuming game
+  (assembler#636).
 - **World positions** (`getWorldPosition`) everywhere positions are compared —
   parented entities (storages under rooms) are meaningless in local coords.
 

--- a/src/nav/controller.zig
+++ b/src/nav/controller.zig
@@ -1657,7 +1657,7 @@ fn GameCtx(comptime GameType: type) type {
 /// Emit a `pathfinder__*` game event through a comptime gate instead of
 /// a raw union literal.
 ///
-/// Why the indirection: `game.emit(.{ .pathfinder__arrived = … })` is a
+/// Why the indirection: `game.emit(.{ .pathfinder__<event> = … })` is a
 /// hard compile-time reference to that `GameEvents` variant. Under the
 /// assembler's consumption filter (assembler#630, ≥0.93.0) events with
 /// no subscriber are elided from the generated union — an ungated emit
@@ -1728,17 +1728,25 @@ inline fn emitGameEvent(game: anytype, comptime tag: []const u8, payload: anytyp
 // deliberately has no mock game (see CLAUDE.md), but these games mock
 // only the `GameEvents`/`emit` sliver of the contract, which is
 // exactly the surface under test.
+//
+// Tags here are SYNTHETIC (`prov__*`), never the plugin's real
+// `pathfinder__*` tags: the assembler's ungated-emit detector
+// (labelle-assembler#636) treats any dot-prefixed real tag in the
+// provider's source — test switch arms included — as an ungated emit
+// and force-keeps that event in every consuming game, defeating
+// elision. The helper's mechanics don't depend on the tag names;
+// real-tag coverage lives in consuming-game builds.
 
-/// A game whose GameEvents union declares pathfinder tags.
-/// `pathfinder__arrived` uses u64 entity fields to prove the @intCast
-/// widening; `pathfinder__graph_rebuilt` carries a defaulted field the
-/// emit-site payload omits.
+/// A game whose GameEvents union declares the emitted (synthetic)
+/// tags. `prov__arrived` uses u64 entity fields to prove the @intCast
+/// widening; `prov__rebuilt` carries a defaulted field the emit-site
+/// payload omits.
 const EmitRecordingGame = struct {
     // `pub` on purpose: real games export GameEvents for cross-module
     // access — mirror the production contract.
     pub const GameEvents = union(enum) {
-        pathfinder__arrived: struct { entity: u64, node_entity: u64 },
-        pathfinder__graph_rebuilt: struct {
+        prov__arrived: struct { entity: u64, node_entity: u64 },
+        prov__rebuilt: struct {
             epoch: u64,
             extra: f32 = 99.5,
         },
@@ -1755,13 +1763,13 @@ const EmitRecordingGame = struct {
 
 test "emitGameEvent builds the typed payload and widens int fields" {
     var game = EmitRecordingGame{};
-    emitGameEvent(&game, "pathfinder__arrived", .{
+    emitGameEvent(&game, "prov__arrived", .{
         .entity = @as(u32, 7),
         .node_entity = @as(u32, 42),
     });
     try std.testing.expectEqual(@as(usize, 1), game.count);
     switch (game.last.?) {
-        .pathfinder__arrived => |p| {
+        .prov__arrived => |p| {
             try std.testing.expectEqual(@as(u64, 7), p.entity);
             try std.testing.expectEqual(@as(u64, 42), p.node_entity);
         },
@@ -1771,12 +1779,12 @@ test "emitGameEvent builds the typed payload and widens int fields" {
 
 test "emitGameEvent fills omitted fields from their declared defaults" {
     var game = EmitRecordingGame{};
-    emitGameEvent(&game, "pathfinder__graph_rebuilt", .{
+    emitGameEvent(&game, "prov__rebuilt", .{
         .epoch = @as(u64, 3),
     });
     try std.testing.expectEqual(@as(usize, 1), game.count);
     switch (game.last.?) {
-        .pathfinder__graph_rebuilt => |p| {
+        .prov__rebuilt => |p| {
             try std.testing.expectEqual(@as(u64, 3), p.epoch);
             try std.testing.expectEqual(@as(f32, 99.5), p.extra);
         },
@@ -1788,7 +1796,7 @@ test "emitGameEvent no-ops when the union lacks the requested tag" {
     // The consumption-filter case this whole helper exists for: the
     // game consumes `arrived` but the assembler elided `node_removed`.
     var game = EmitRecordingGame{};
-    emitGameEvent(&game, "pathfinder__node_removed", .{
+    emitGameEvent(&game, "prov__missing", .{
         .node_id = @as(u32, 5),
     });
     try std.testing.expectEqual(@as(usize, 0), game.count);
@@ -1805,7 +1813,7 @@ test "emitGameEvent no-ops for void and non-union GameEvents" {
         pub const GameEvents = void;
     };
     var void_game = VoidGame{};
-    emitGameEvent(&void_game, "pathfinder__arrived", .{
+    emitGameEvent(&void_game, "prov__arrived", .{
         .entity = @as(u32, 1),
         .node_entity = @as(u32, 2),
     });
@@ -1814,7 +1822,7 @@ test "emitGameEvent no-ops for void and non-union GameEvents" {
         pub const GameEvents = struct {};
     };
     var struct_game = StructGame{};
-    emitGameEvent(&struct_game, "pathfinder__arrived", .{
+    emitGameEvent(&struct_game, "prov__arrived", .{
         .entity = @as(u32, 1),
         .node_entity = @as(u32, 2),
     });
@@ -1824,7 +1832,7 @@ test "emitGameEvent no-ops when the game has no GameEvents decl" {
     // Same contract: compiling is the assertion.
     const BareGame = struct {};
     var game = BareGame{};
-    emitGameEvent(&game, "pathfinder__arrived", .{
+    emitGameEvent(&game, "prov__arrived", .{
         .entity = @as(u32, 1),
         .node_entity = @as(u32, 2),
     });


### PR DESCRIPTION
## What

Adopts the synthetic-tag test convention from labelle-toolkit/labelle-assembler#636 (Option 1): the emitGameEvent tests' synthetic `GameEvents` union, switch arms, and tag strings (from #53) now use synthetic `prov__*` names instead of the plugin's real `pathfinder__*` tags, and the one dot-prefixed doc-comment example (`.pathfinder__arrived`) is de-needled to `.pathfinder__<event>`. The convention is documented next to the gated-emit contract bullet in CLAUDE.md.

## Why

The assembler's ungated-emit detector (assembler#634) force-keeps any plugin event whose qualified tag appears **dot-prefixed** anywhere in the provider's source — test switch arms and doc comments included. Pathfinding's emits have been fully string-gated since 4.0.2 (#52/#53), yet the test code alone force-kept `pathfinder__arrived` and `pathfinder__graph_rebuilt` in every consuming game (observed live on flying-platform, assembler 0.93.1).

Coverage is equivalent: these tests exercise the helper's comptime-gate mechanics (field mapping, `@intCast` widening, default filling, every no-op shape), which don't depend on the tag names. Real-tag coverage lives in consuming-game builds.

## Detector needle scan (`.` + qualified tag, over `.zig`/`.zon`/`.json`/`.jsonc`)

Before (2 of 4 tags force-kept):
```
src/nav/controller.zig:1660  /// … `game.emit(.{ .pathfinder__arrived = … })`   (doc comment)
src/nav/controller.zig:1764  .pathfinder__arrived => |p| {                       (test switch arm)
src/nav/controller.zig:1779  .pathfinder__graph_rebuilt => |p| {                 (test switch arm)
```

After: **zero matches** for all four tags (`arrived`, `navigation_failed`, `graph_rebuilt`, `node_removed`) — every pathfinder event is now kept only by genuine consumers or elided.

## Verified end-to-end on flying-platform (assembler 0.93.1, local: override, nothing committed there)

Baseline (pathfinding 4.0.2 release pin):
```
// force-kept (provider emits ungated): pathfinder__arrived
// force-kept (provider emits ungated): pathfinder__graph_rebuilt
```
With this branch:
```
// elided (no consumer): pathfinder__graph_rebuilt
pathfinder__arrived: @import("pathfinder").Events.arrived   // genuine consumer keep
```

`zig build test` green before and after (exit-checked).

Refs labelle-toolkit/labelle-assembler#636 — that issue closes when this and the sibling PR labelle-toolkit/labelle-box2d#22 both merge.

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-pathfinding/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787070755&installation_id=146340424&pr_number=54&repository=labelle-toolkit%2Flabelle-pathfinding&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-pathfinding%2Fpull%2F54&signature=6cb4974370a2dc683b4b68c0f609e90ffc1d66f5562fff854397a2c214926340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
